### PR TITLE
(WIP) Adding common global macros, functions, and imports.

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		04F39590186CF80100B0D6FC /* TOCViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 04F3958F186CF80100B0D6FC /* TOCViewController.m */; };
 		08D631F71A69B1AB00D87AD0 /* WMFImageGalleryViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D631F61A69B1AB00D87AD0 /* WMFImageGalleryViewController.m */; };
 		0EA4402E1AA6281200B09DBA /* NSDateFormatter+WMFExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EA4402D1AA6281200B09DBA /* NSDateFormatter+WMFExtensions.m */; };
+		0EB019241AB26EEA004CA09D /* WMFFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EB019231AB26EEA004CA09D /* WMFFunctions.m */; };
 		701FF5EE601DEA3FCAB7EFD3 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D82982ED992F47428037BDF2 /* libPods.a */; };
 		954BA118838BF8BA6B01C34A /* libPods-WikipediaUnitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8CE61C6963F825760822A28A /* libPods-WikipediaUnitTests.a */; };
 		BC0FED621AAA0263002488D7 /* WMFCodingStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = BC6FEAE01A9B7EFD00A1D890 /* WMFCodingStyle.m */; };
@@ -702,6 +703,10 @@
 		08D631F91A69B8CD00D87AD0 /* WMFImageGalleryCollectionViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WMFImageGalleryCollectionViewCell.m; path = "Image Gallery/WMFImageGalleryCollectionViewCell.m"; sourceTree = "<group>"; };
 		0EA4402C1AA6281200B09DBA /* NSDateFormatter+WMFExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSDateFormatter+WMFExtensions.h"; path = "Wikipedia/Categories/NSDateFormatter+WMFExtensions.h"; sourceTree = SOURCE_ROOT; };
 		0EA4402D1AA6281200B09DBA /* NSDateFormatter+WMFExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSDateFormatter+WMFExtensions.m"; path = "Wikipedia/Categories/NSDateFormatter+WMFExtensions.m"; sourceTree = SOURCE_ROOT; };
+		0EB019201AB26EEA004CA09D /* Global.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Global.h; sourceTree = "<group>"; };
+		0EB019211AB26EEA004CA09D /* WMFMacroUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WMFMacroUtilities.h; sourceTree = "<group>"; };
+		0EB019221AB26EEA004CA09D /* WMFFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WMFFunctions.h; sourceTree = "<group>"; };
+		0EB019231AB26EEA004CA09D /* WMFFunctions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WMFFunctions.m; sourceTree = "<group>"; };
 		17A2F22335C5256576CEDBDD /* Pods-WikipediaUnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WikipediaUnitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-WikipediaUnitTests/Pods-WikipediaUnitTests.release.xcconfig"; sourceTree = "<group>"; };
 		357504E50DA104E39C6ACFEB /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		8CE61C6963F825760822A28A /* libPods-WikipediaUnitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-WikipediaUnitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1978,6 +1983,17 @@
 			name = "Image Gallery";
 			sourceTree = "<group>";
 		};
+		0EB0191F1AB26EEA004CA09D /* Global */ = {
+			isa = PBXGroup;
+			children = (
+				0EB019201AB26EEA004CA09D /* Global.h */,
+				0EB019211AB26EEA004CA09D /* WMFMacroUtilities.h */,
+				0EB019221AB26EEA004CA09D /* WMFFunctions.h */,
+				0EB019231AB26EEA004CA09D /* WMFFunctions.m */,
+			);
+			path = Global;
+			sourceTree = "<group>";
+		};
 		BC8309941A7BF935003FC5C7 /* WikipediaUnitTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -2264,6 +2280,7 @@
 				D46CD8C018A1AC4F0042959E /* InfoPlist.strings */,
 				D46CD8C218A1AC4F0042959E /* Localizable.strings */,
 				045A9F0C18F6090E0057EA85 /* assets */,
+				0EB0191F1AB26EEA004CA09D /* Global */,
 				04272E771940EEBC00CC682F /* AssetsFile */,
 				04C43AB7183442FC006C643B /* Categories */,
 				0460F8D919B0F90E001BC59B /* CenteredPathView */,
@@ -2993,6 +3010,7 @@
 				04C0A0781936786000D55325 /* UIViewController+ModalPresent.m in Sources */,
 				BC86B9361A92966B00B4C039 /* AFHTTPRequestOperationManager+UniqueRequests.m in Sources */,
 				D4991449181D51DE00E6073C /* AppDelegate.m in Sources */,
+				0EB019241AB26EEA004CA09D /* WMFFunctions.m in Sources */,
 				BCB669A81A83F6C400C7B1FE /* MWKUser.m in Sources */,
 				BCB669AB1A83F6C400C7B1FE /* MWKProtectionStatus.m in Sources */,
 				BCC185E01A9EC836005378F8 /* UIButton+FrameUtils.m in Sources */,

--- a/wikipedia/Global/Global.h
+++ b/wikipedia/Global/Global.h
@@ -1,0 +1,87 @@
+
+#pragma mark - 3rd Party
+
+#import <BlocksKit/BlocksKit.h>
+#import <Masonry/Masonry.h>
+
+#pragma mark - Generic Block Definitions
+
+typedef BOOL (^ WMFBOOLBlock)(void);
+typedef void (^ WMFSuccessBlock)(BOOL success);
+typedef void (^ WMFErrorBlock)(NSError* error);
+typedef void (^ WMFFetchBlock)(id object, NSError* error);
+typedef void (^ WMFFetchImageBlock)(UIImage* image, NSError* error);
+typedef void (^ WMFFetchArrayBlock)(NSArray* array, NSError* error);
+
+#pragma mark - Utility Macros and Functions
+
+#import "WMFMacroUtilities.h"
+#import "WMFFunctions.h"
+
+#pragma mark - Foundation extensions
+
+#import "NSObject+Extras.h"
+#import "NSString+Extras.h"
+#import "NSString+FormattedAttributedString.h"
+#import "NSString+WMFHTMLParsing.h"
+#import "NSMutableDictionary+WMFMaybeSet.h"
+#import "NSArray+Predicate.h"
+#import "NSArray+WMFExtensions.h"
+#import "NSArray+BKIndex.h"
+#import "NSDateFormatter+WMFExtensions.h"
+#import "NSDate-Utilities.h"
+
+#pragma mark - UIKit extensions
+
+#import "UIColor+WMFHexColor.h"
+#import "UIView+WMFDefaultNib.h"
+#import "UIView+WMFFrameUtils.h"
+#import "UIView+WMFSearchSubviews.h"
+#import "UIView+WMFRoundCorners.h"
+
+#pragma mark - Model Classes
+
+@class MWKDataStore;
+@class MWKUserDataStore;
+
+@class MWKDataObject;
+
+@class MWKSite;
+@class MWKTitle;
+@class MWKArticle;
+@class MWKSectionList;
+@class MWKSection;
+
+@class MWKImageList;
+@class MWKImage;
+@class MWKImageInfo;
+
+@class MWKLicense;
+
+@class MWKHistoryList;
+@class MWKHistoryEntry;
+
+@class MWKSavedPageList;
+@class MWKSavedPageEntry;
+
+@class MWKRecentSearchList;
+@class MWKRecentSearchEntry;
+
+@class MWKProtectionStatus;
+@class MWKUser;
+
+#pragma mark - Global View Controllers
+
+#warning refactor to remove the following as soon as possible
+
+#import "RootViewController.h"
+#import "CenterNavController.h"
+
+#define ROOT ((RootViewController*)[UIApplication sharedApplication].delegate.window.rootViewController)
+#define NAV ROOT.centerNavController
+
+
+
+
+
+

--- a/wikipedia/Global/WMFFunctions.h
+++ b/wikipedia/Global/WMFFunctions.h
@@ -1,0 +1,88 @@
+
+#pragma mark - App Version
+
+static inline NSString* applicationVersion(){
+    NSDictionary* bundleInfo = [[NSBundle mainBundle] infoDictionary];
+
+    return [NSString stringWithFormat:@"%@ (%@)", [bundleInfo objectForKey:@"CFBundleShortVersionString"], [bundleInfo objectForKey:@"CFBundleVersion"]];
+}
+
+#pragma mark - App Directories
+
+static inline NSString* documentsDirectory(){
+    return [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES)lastObject];
+}
+
+static inline NSString* cachesDirectory(){
+    return [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES)lastObject];
+}
+
+static inline NSString* tempDirectory(){
+    return NSTemporaryDirectory();
+}
+
+static inline NSString* fileNameBasedOnCurrentTime(NSString* prefix, NSString* suffix) {
+    NSString* fileName = [NSString stringWithFormat:@"%@%.0f.%@", prefix, [NSDate timeIntervalSinceReferenceDate] * 1000.0, suffix];
+
+    return fileName;
+}
+
+#pragma mark - iCloud Skip Backup
+
+BOOL addSkipBackupAttributeToItemAtURL(NSURL* URL);
+
+#pragma mark - size
+
+NSUInteger sizeOfFolderContentsInBytes(NSString* folderPath);
+double bytesWithMegaBytes(long long megaBytes);
+double megaBytesWithBytes(long long bytes);
+double gigaBytesWithBytes(long long bytes);
+NSString* prettySizeStringWithBytesRounded(long long bytes); // includes MB or GB in string
+NSString* prettySizeStringWithBytesFloored(long long bytes); // same as above, but floored
+
+#pragma mark - time
+
+float nanosecondsWithSeconds(float seconds);
+
+dispatch_time_t dispatchTimeFromNow(float seconds);
+
+static inline NSString* timeZoneString(){
+    NSTimeZone* ltz        = [NSTimeZone localTimeZone];
+    NSString* abbreviation = [ltz abbreviation];
+
+    return abbreviation;
+}
+
+CGFloat measureTimeBlock(void (^ block)(void));
+
+#pragma mark - NSRange
+
+BOOL rangesAreContiguous(NSRange first, NSRange second);
+
+NSRange rangeWithFirstAndLastIndexes(NSUInteger first, NSUInteger last);
+
+#pragma mark - Dispatch Help
+
+void dispatchOnMainQueue(dispatch_block_t block);
+void dispatchOnMainQueueAfterDelayInSeconds(float delay, dispatch_block_t block);
+
+void dispatchOnBackgroundQueue(dispatch_block_t block);
+
+void dispatchAfterDelayInSeconds(float delay, dispatch_queue_t queue, dispatch_block_t block);
+
+#pragma mark - Degrees
+
+#define DEGREES_TO_RADIANS(angle) ((angle) / 180.0 * M_PI)
+#define RADIANS_TO_DEGREES(angle) ((angle) * 180.0 / M_PI)
+
+#pragma mark - Progress
+
+typedef struct {
+    unsigned long long complete;
+    unsigned long long total;
+    double ratio;
+} Progress;
+
+Progress progressMake(unsigned long long complete, unsigned long long total);
+extern Progress const kProgressZero;
+

--- a/wikipedia/Global/WMFFunctions.m
+++ b/wikipedia/Global/WMFFunctions.m
@@ -1,0 +1,215 @@
+
+#import "WMFFunctions.h"
+#import <sys/xattr.h>
+#import <mach/mach_time.h>
+#import "WMFMacroUtilities.h"
+
+BOOL rangesAreContiguous(NSRange first, NSRange second){
+    NSIndexSet* firstIndexes  = [NSIndexSet indexSetWithIndexesInRange:first];
+    NSIndexSet* secondIndexes = [NSIndexSet indexSetWithIndexesInRange:second];
+
+    NSUInteger endOfFirstRange       = [firstIndexes lastIndex];
+    NSUInteger beginingOfSecondRange = [secondIndexes firstIndex];
+
+    if (beginingOfSecondRange - endOfFirstRange == 1) {
+        return YES;
+    }
+
+    return NO;
+}
+
+NSRange rangeWithFirstAndLastIndexes(NSUInteger first, NSUInteger last){
+    if (last < first) {
+        return NSMakeRange(0, 0);
+    }
+
+    if (first == NSNotFound || last == NSNotFound) {
+        return NSMakeRange(0, 0);
+    }
+
+    NSUInteger length = last - first + 1;
+
+    NSRange r = NSMakeRange(first, length);
+    return r;
+}
+
+float nanosecondsWithSeconds(float seconds){
+    return (seconds * 1000000000);
+}
+
+CGFloat measureTimeBlock(void (^ block)(void)) {
+    mach_timebase_info_data_t info;
+
+    if (mach_timebase_info(&info) != KERN_SUCCESS) {
+        return -1.0;
+    }
+
+    uint64_t start = mach_absolute_time();
+    block();
+    uint64_t end     = mach_absolute_time();
+    uint64_t elapsed = end - start;
+
+    uint64_t nanos = elapsed * info.numer / info.denom;
+    return (CGFloat)nanos / NSEC_PER_SEC;
+}
+
+dispatch_time_t dispatchTimeFromNow(float seconds){
+    return dispatch_time(DISPATCH_TIME_NOW, nanosecondsWithSeconds(seconds));
+}
+
+BOOL addSkipBackupAttributeToItemAtURL(NSURL* URL){
+#ifdef DEBUG
+
+    assert([[NSFileManager defaultManager] fileExistsAtPath:[URL path]]);
+
+#endif
+
+    if (IS_OS_5_1_OR_LATER) {
+        NSError* error = nil;
+        BOOL success   = [URL setResourceValue:[NSNumber numberWithBool:YES]
+                                        forKey:NSURLIsExcludedFromBackupKey error:&error];
+        if (!success) {
+            NSLog(@"Error excluding %@ from backup %@", [URL lastPathComponent], error);
+        }
+        return success;
+    } else if (IS_OS_5_0_1_OR_LATER) {
+        const char* filePath = [[URL path] fileSystemRepresentation];
+
+        const char* attrName = "com.apple.MobileBackup";
+        u_int8_t attrValue   = 1;
+
+        int result = setxattr(filePath, attrName, &attrValue, sizeof(attrValue), 0, 0);
+        return result == 0;
+    }
+
+    return NO;
+}
+
+NSUInteger sizeOfFolderContentsInBytes(NSString* folderPath){
+    NSError* error    = nil;
+    NSArray* contents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:folderPath error:&error];
+
+    if (error != nil) {
+        return NSNotFound;
+    }
+
+    double bytes = 0.0;
+    for (NSString* eachFile in contents) {
+        NSDictionary* meta = [[NSFileManager defaultManager] attributesOfItemAtPath:[folderPath stringByAppendingPathComponent:eachFile] error:&error];
+
+        if (error != nil) {
+            break;
+        }
+
+        NSNumber* fileSize = [meta objectForKey:NSFileSize];
+        bytes += [fileSize unsignedIntegerValue];
+    }
+
+    if (error != nil) {
+        return NSNotFound;
+    }
+
+    return bytes;
+}
+
+double bytesWithMegaBytes(long long megaBytes){
+    NSNumber* mb = [NSNumber numberWithLongLong:megaBytes];
+
+    double mbAsDouble = [mb doubleValue];
+
+    double b = mbAsDouble * 1048576.0;
+
+    return b;
+}
+
+double megaBytesWithBytes(long long bytes){
+    NSNumber* b = [NSNumber numberWithLongLong:bytes];
+
+    double bytesAsDouble = [b doubleValue];
+
+    double mb = bytesAsDouble / 1048576.0;
+
+    return mb;
+}
+
+double gigaBytesWithBytes(long long bytes){
+    NSNumber* b = [NSNumber numberWithLongLong:bytes];
+
+    double bytesAsDouble = [b doubleValue];
+
+    double gb = bytesAsDouble / 1073741824.0;
+
+    return gb;
+}
+
+NSString* prettySizeStringWithBytesRounded(long long bytes){
+    NSString* size = nil;
+
+    if (bytes <= 524288000) { // smaller than 500 MB
+        double mb = megaBytesWithBytes(bytes);
+        mb   = round(mb);
+        size = [NSString stringWithFormat:@"%.f MB", mb];
+    } else {
+        double gb = gigaBytesWithBytes(bytes);
+        gb   = round(gb / 0.1) * 0.1;
+        size = [NSString stringWithFormat:@"%.1f GB", gb];
+    }
+    return size;
+}
+
+NSString* prettySizeStringWithBytesFloored(long long bytes){
+    NSString* size = nil;
+
+    if (bytes <= 524288000) { // smaller than 500 MB
+        double mb = megaBytesWithBytes(bytes);
+        mb   = floor(mb);
+        size = [NSString stringWithFormat:@"%.f MB", mb];
+    } else {
+        double gb = gigaBytesWithBytes(bytes);
+        gb   = floor(gb / 0.1) * 0.1;
+        size = [NSString stringWithFormat:@"%.1f GB", gb];
+    }
+    return size;
+}
+
+void dispatchOnMainQueue(dispatch_block_t block){
+    dispatch_async(dispatch_get_main_queue(), block);
+}
+
+void dispatchOnBackgroundQueue(dispatch_block_t block){
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), block);
+}
+
+void dispatchOnMainQueueAfterDelayInSeconds(float delay, dispatch_block_t block){
+    dispatchAfterDelayInSeconds(delay, dispatch_get_main_queue(), block);
+}
+
+void dispatchAfterDelayInSeconds(float delay, dispatch_queue_t queue, dispatch_block_t block){
+    dispatch_after(dispatchTimeFromNow(delay), queue, block);
+}
+
+Progress progressMake(unsigned long long complete, unsigned long long total){
+    if (total == 0) {
+        return kProgressZero;
+    }
+
+    Progress p;
+
+    p.total    = total;
+    p.complete = complete;
+
+    NSNumber* t = [NSNumber numberWithLongLong:total];
+    NSNumber* c = [NSNumber numberWithLongLong:complete];
+
+    double r = [c doubleValue] / [t doubleValue];
+
+    p.ratio = r;
+
+    return p;
+}
+
+Progress const kProgressZero = {
+    0,
+    0,
+    0.0
+};

--- a/wikipedia/Global/WMFMacroUtilities.h
+++ b/wikipedia/Global/WMFMacroUtilities.h
@@ -1,0 +1,104 @@
+#if (TARGET_OS_EMBEDDED || TARGET_OS_IPHONE)
+
+//Retina Detection
+#define IS_RETINA       ([[UIScreen mainScreen] scale] > 1) ? YES : NO
+
+//Screen Size Detection
+#define IS_3point5IN    ([[UIScreen mainScreen] bounds].size.height == 480)
+#define IS_4IN          ([[UIScreen mainScreen] bounds].size.height == 568)
+
+//Super Slow iPad Detection
+#define IS_IPAD   (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
+#define IS_IPAD_1 (IS_IPAD && ![UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera])
+
+//OS Version Detection
+#define VERSION_GREATER_THAN(v1, v2)               ([v1 compare:v2 options:NSNumericSearch] == NSOrderedDescending)
+
+#define SYSTEM_VERSION_EQUAL_TO(v)                 ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedSame)
+#define SYSTEM_VERSION_GREATER_THAN(v)             ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedDescending)
+#define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v) ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
+#define SYSTEM_VERSION_LESS_THAN(v)                ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
+#define SYSTEM_VERSION_LESS_THAN_OR_EQUAL_TO(v)    ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedDescending)
+
+#define IS_OS_8_OR_LATER     (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"8.0"))
+#define IS_OS_7_OR_LATER     (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"7.0"))
+#define IS_OS_6_OR_LATER     (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"6.0"))
+#define IS_OS_5_1_OR_LATER   (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"5.1"))
+#define IS_OS_5_0_1_OR_LATER (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"5.0.1"))
+#define IS_OS_5_0            (SYSTEM_VERSION_EQUAL_TO(@"5.0"))
+#define IS_OS_5_OR_LATER     (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"5.0"))
+#define IS_PRIOR_TO_OS_5     (SYSTEM_VERSION_LESS_THAN(@"5.0"))
+#define IS_OS_4_OR_LATER     (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"4.0"))
+#define IS_OS_32_OR_LATER    (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"3.2"))
+
+#endif
+
+#define ASSERT_TRUE_OR_LOG(condition, ...) do { if (!(condition)) { ALog(__VA_ARGS__); } } while (0)
+
+#ifdef DEBUG
+
+#warning remove redefinition of NSLog so that we can still log important data in production builds (used DEBUGLOG instead)
+#define NSLog(FORMAT, ...) fprintf(stderr, "\n%s Line %d\n\t%s\n", __PRETTY_FUNCTION__, __LINE__, [[NSString stringWithFormat:FORMAT, ## __VA_ARGS__] UTF8String]);
+
+#define DEBUGLOG(format, ...)              NSLog(@"%s:%@", __PRETTY_FUNCTION__, [NSString stringWithFormat:format, ## __VA_ARGS__]);
+#define MARK        debugLog(@"%s", __PRETTY_FUNCTION__);
+#define START_TIMER NSTimeInterval start                       = [NSDate timeIntervalSinceReferenceDate];
+#define END_TIMER(msg)                     NSTimeInterval stop = [NSDate timeIntervalSinceReferenceDate]; debugLog([NSString stringWithFormat:@"%@ Time = %f", msg, stop - start]);
+
+//Log specific objects and structs
+#define ERRORLOG(object)                   (NSLog(@"" @"%s:" # object @"Error! %@", __PRETTY_FUNCTION__, [object description]));
+#define DECIMALLOG(object)                       (NSLog(@"" # object @" %d", object));
+#define FLOATLOG(object)                       (NSLog(@"" # object @" %f", object));
+#define OBJECTLOG(object)                 (NSLog(@"" @"%s:" # object @" %@", __PRETTY_FUNCTION__, [object description]));
+#define POINTLOG(point)                    (NSLog(@""  # point @" x:%f y:%f", point.x, point.y));
+#define SIZELOG(size)                      (NSLog(@""  # size @" width:%f height:%f", size.width, size.height));
+#define RECTLOG(rect)                      (NSLog(@""  # rect @" x:%f y:%f w:%f h:%f", rect.origin.x, rect.origin.y, rect.size.width, rect.size.height));
+
+#define SELECTOR_LOG      (NSLog(@"%@ in %s", NSStringFromSelector(_cmd), __FILE__));
+#define METHOD_LOG        (NSLog(@"%@ %s\n%@", NSStringFromSelector(_cmd), __FILE__, self))
+#define METHOD_LOG_THREAD (NSLog(@"%@ %@ %s\n%@", NSStringFromSelector(_cmd), [NSThread currentThread], __FILE__, self))
+
+#define ASSERT_OR_LOG(...)                          [[NSAssertionHandler currentHandler] handleFailureInFunction :[NSString stringWithCString:__PRETTY_FUNCTION__ encoding:NSUTF8StringEncoding] file :[NSString stringWithCString:__FILE__ encoding:NSUTF8StringEncoding] lineNumber : __LINE__ description : __VA_ARGS__]
+#define NOT_NIL_ASSERT(x)                  NSAssert4((x != nil), @"\n\n    ****  Unexpected Nil Assertion  ****\n    ****  " # x @" is nil.\nin file:%s at line %i in Method %@ with object:\n %@", __FILE__, __LINE__, NSStringFromSelector(_cmd), self)
+#define NIL_ASSERT(x)                      NSAssert4((x == nil), @"\n\n    ****  Unexpected Non-Nil Assertion  ****\n    ****  " # x @" is non-nil.\nin file:%s at line %i in Method %@ with object:\n %@", __FILE__, __LINE__, NSStringFromSelector(_cmd), self)
+#define ALWAYS_ASSERT     NSAssert4(0, @"\n\n    ****  Unexpected Assertion  **** \nAssertion in file:%s at line %i in Method %@ with object:\n %@", __FILE__, __LINE__, NSStringFromSelector(_cmd), self)
+#define MSG_ASSERT(x)                      NSAssert5(0, @"\n\n    ****  Unexpected Assertion  **** \nReason: %@\nAssertion in file:%s at line %i in Method %@ with object:\n %@", x, __FILE__, __LINE__, NSStringFromSelector(_cmd), self)
+#define ASSERT_TRUE(test)                  NSAssert4(test, @"\n\n    ****  Unexpected Assertion  **** \nAssertion in file:%s at line %i in Method %@ with object:\n %@", __FILE__, __LINE__, NSStringFromSelector(_cmd), self)
+#define MSG_ASSERT_TRUE(test, msg)         NSAssert5(test, @"\n\n    ****  Unexpected Assertion  **** \nReason: %@\nAssertion in file:%s at line %i in Method %@ with object:\n %@", msg, __FILE__, __LINE__, NSStringFromSelector(_cmd), self)
+
+#else
+
+#define NSLog(...) {}
+
+#define DEBUGLOG(format, ...)
+#define MARK
+#define START_TIMER
+#define END_TIMER(msg)
+
+#define ERRORLOG(object)
+#define DECIMALLOG(object)
+#define FLOATLOG(object)
+#define OBJECTLOG(object)
+
+#define POINTLOG(point)
+#define SIZELOG(size)
+#define RECTLOG(rect)
+
+#define SELECTOR_LOG
+#define METHOD_LOG
+#define METHOD_LOG_THREAD
+
+#define ASSERT_OR_LOG(...) NSLog(@"%s %@", __PRETTY_FUNCTION__, [NSString stringWithFormat:__VA_ARGS__])
+#define NOT_NIL_ASSERT(x)
+#define NIL_ASSERT(x)
+#define ALWAYS_ASSERT
+#define MSG_ASSERT(x)
+#define ASSERT_TRUE(test)
+#define MSG_ASSERT_TRUE(test, msg)
+
+#ifndef NS_BLOCK_ASSERTIONS
+#define NS_BLOCK_ASSERTIONS
+#endif
+
+#endif
+

--- a/wikipedia/View Controllers/Nearby/NearbyThumbnailView.m
+++ b/wikipedia/View Controllers/Nearby/NearbyThumbnailView.m
@@ -15,9 +15,6 @@
 #define NEARBY_COMPASS_LINE_COUNT 57
 #define NEARBY_OPPOSITE_LINE_WIDTH 2.0f
 
-#define RADIANS_TO_DEGREES(radians) ((radians) * (180.0 / M_PI))
-#define DEGREES_TO_RADIANS(angle) ((angle) / 180.0 * M_PI)
-
 @interface NearbyThumbnailView ()
 
 @property (strong, nonatomic) UIImageView* thumbImageView;

--- a/wikipedia/View Controllers/Nearby/NearbyViewController.m
+++ b/wikipedia/View Controllers/Nearby/NearbyViewController.m
@@ -21,9 +21,6 @@
 
 #define TABLE_CELL_ID @"NearbyResultCollectionCell"
 
-#define RADIANS_TO_DEGREES(radians) ((radians) * (180.0 / M_PI))
-#define DEGREES_TO_RADIANS(angle) ((angle) / 180.0 * M_PI)
-
 @interface NearbyViewController ()
 
 @property (strong, nonatomic) NSArray* nearbyDataArray;

--- a/wikipedia/Wikipedia-Prefix.pch
+++ b/wikipedia/Wikipedia-Prefix.pch
@@ -14,19 +14,6 @@
 
     #import <UIKit/UIKit.h>
     #import <Foundation/Foundation.h>
-
-    #ifndef DEBUG
-        #define NSLog(...) {}
-    #else
-        #define NSLog(FORMAT, ...) fprintf(stderr,"\n%s Line %d\n\t%s\n", __PRETTY_FUNCTION__, __LINE__, [[NSString stringWithFormat:FORMAT, ##__VA_ARGS__] UTF8String]);
-    #endif // end DEBUG
-
-    #import "RootViewController.h"
-    #import "CenterNavController.h"
-
-    #define ROOT ((RootViewController *)[UIApplication sharedApplication].delegate.window.rootViewController)
-    #define NAV ROOT.centerNavController
-
-    #import "MediaWikiKit.h"
+    #import "Global.h"
 
 #endif // end __OBJC__


### PR DESCRIPTION
This patch contains some basic infrastructure to share through the code base.
I repurposed some common files I used previously for a start, but wanted to
get feedback fro the team on what we would like to include.

Please suggest additions / removals or even better just update the patch yourself!

Import global header in pch folder (so we never have to edit the PCH directly)
Import common 3rd party libs in global (blocks kit masonry - things we use throughout)
Add common block type defs to global
Import Foundation and UIKit categories in global (so these are available everywhere)
Forward declare media wiki kit classes in global header (so the codebase can reference these in headers)
Add macro utilities file (some device detection, os detection, logs, assertions)
Add common functions file (functions to get directories, sizes, dispatch helpers, etc…)

Change-Id: Idddac4955fdff58e42cbcd3114cc3d56736c1810
